### PR TITLE
Add erlang-dev package in the install list

### DIFF
--- a/elixirbuildbase/Dockerfile
+++ b/elixirbuildbase/Dockerfile
@@ -15,11 +15,11 @@ RUN \
       openssl-dev \
       ncurses-dev \
       unixodbc-dev \
-      zlib-dev && \
+      zlib-dev \
+      erlang-dev && \      
     # Install Erlang/OTP build deps
     apk -U add --virtual .erlang-build \
       build-base \
-      erlang-dev \
       perl-dev \
       gcc && \
     export ERLANG_SOURCE=otp_src_$ERLANG_VERSION && \

--- a/elixirbuildbase/Dockerfile
+++ b/elixirbuildbase/Dockerfile
@@ -19,6 +19,7 @@ RUN \
     # Install Erlang/OTP build deps
     apk -U add --virtual .erlang-build \
       build-base \
+      erlang-dev \
       perl-dev \
       gcc && \
     export ERLANG_SOURCE=otp_src_$ERLANG_VERSION && \


### PR DESCRIPTION
Pollinator build randomly fails with this error

```
==> comeonin
mkdir -p priv
cc -g -O3 -Wall -I/usr/lib/erlang/erts-8.1/include -Ic_src -fPIC -shared  c_src/bcrypt_nif.c c_src/blowfish.c -o priv/bcrypt_nif.so
make: cc: Command not found
Makefile:29: recipe for target 'priv/bcrypt_nif.so' failed
make: *** [priv/bcrypt_nif.so] Error 127
could not compile dependency :comeonin, "mix compile" failed. You can recompile this dependency with "mix deps.compile comeonin", update it with "mix deps.update comeonin" or clean it with "mix deps.clean comeonin"
** (Mix) Could not compile with "make" (exit status: 2).
Depending on your OS, make sure to follow these instructions:
  * Mac OS X: You need to have gcc and make installed. Try running the
    commands "gcc --version" and / or "make --version". If these programs
    are not installed, you will be prompted to install them.
  * Linux: You need to have gcc and make installed. If you are using
    Ubuntu or any other Debian-based system, install the packages
    "build-essential". Also install "erlang-dev" package if not
    included in your Erlang/OTP version. If you're on Fedora, run
    "dnf group install 'Development Tools'".
```

While we don't know the actual reason, most of the github issues around this problem and threads on SO hint that having `build-essentials` and `erlang-dev` packages installed fixed the problem for them. While we already have `build-base` (Alpine equivalent of Ubuntu's `build-essential`) having an `erlang-dev` should help our trial to fix this error.