### PR TITLE
Create gobase 1.8.3 Dockerfile

### DIFF
--- a/gobuildbase/Dockerfile-1.8.3
+++ b/gobuildbase/Dockerfile-1.8.3
@@ -3,4 +3,5 @@ RUN go get -v \
   bitbucket.org/liamstask/goose/cmd/goose \
   github.com/onsi/ginkgo/ginkgo \
   github.com/modocache/gover \
-  github.com/mattn/goveralls
+  github.com/mattn/goveralls \
+  github.com/gobuffalo/packr/...

--- a/gobuildbase/Dockerfile-1.8.3
+++ b/gobuildbase/Dockerfile-1.8.3
@@ -1,0 +1,6 @@
+FROM golang:1.8.3
+RUN go get -v \
+  bitbucket.org/liamstask/goose/cmd/goose \
+  github.com/onsi/ginkgo/ginkgo \
+  github.com/modocache/gover \
+  github.com/mattn/goveralls


### PR DESCRIPTION
## Why is this change necessary?

- server.Shutdown is supported by 1.8.3
